### PR TITLE
#426: Add jpeg, tiff profiles, set file extension accordingly.

### DIFF
--- a/gizmos/WriteTank.gizmo
+++ b/gizmos/WriteTank.gizmo
@@ -115,7 +115,13 @@ Gizmo {
     l "File Type"
     t "The file type to be used for the write node output - this cached value is used if the profile can't be determined"
     +INVISIBLE
- } 
+ }
+ addUserKnob {
+    1 tk_file_extension
+    l "File Extension"
+    t "The extension to be used for the output file - this cached value is used if the profile can't be determined"
+    +INVISIBLE
+ }
  addUserKnob {
     1 tk_file_type_settings
     l "File Type Settings"

--- a/info.yml
+++ b/info.yml
@@ -28,12 +28,12 @@ configuration:
                      of the workflow. These templates need to include the 'version' field
                      and can optionally include the fields 'name', 'width', 'height'
                      (which reflect the image resolution of the render) and 'output' (which
-                     differenciates different write nodes). If you are doing stereo
+                     differentiates different write nodes). If you are doing stereo
                      rendering and want to use Nuke's %V flag, include an 'eye' field.
                      This will be replaced by %V in the paths when the Shotgun Write node
                      computes them.  Finally, you need the templates 'proxy_render_template' 
                      and 'proxy_publish_template' these have the same requirements as the regular 
-                     render and pubish templates but are used when rendering in proxy mode.  If
+                     render and publish templates but are used when rendering in proxy mode.  If
                      these are missing (set to null) then the regular templates will be used 
                      instead."
         allows_empty: True

--- a/info.yml
+++ b/info.yml
@@ -20,7 +20,9 @@ configuration:
                      are supported in this configuration. Each dictionary entry needs to have
                      the following keys: 'name' - a descriptive name for this node. 'file_type' -
                      the file type to use for the renders (exr, cin, dpx etc). This will be
-                     passed to the Nuke write node when rendering. 'settings' - configuration
+                     passed to the Nuke write node when rendering. 'file_extension' - optional
+                     key to specify file extension if it is different from file_type (e.g. jpg
+                     as opposed to jpeg or tif as opposed to tiff). 'settings' - configuration
                      settings for the given file type, as a dictionary. This too will be
                      passed to the write node when rendering. Next, you need two entries
                      named 'render_template' and 'publish_template'
@@ -44,6 +46,9 @@ configuration:
                     type: str
                 file_type:
                     type: str
+                file_extension:
+                    type: str
+                    default_value: ''
                 settings:
                     type: dict
                 tank_type:

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1024,6 +1024,7 @@ class TankWriteNodeHandler(object):
         proxy_render_template = self._app.get_template_by_name(profile["proxy_render_template"])
         proxy_publish_template = self._app.get_template_by_name(profile["proxy_publish_template"])
         file_type = profile["file_type"]
+        file_extension = profile["file_extension"] or profile["file_type"]
         file_settings = profile["settings"]
         tile_color = profile["tile_color"]
         use_node_name = profile["use_node_name"]
@@ -1075,6 +1076,7 @@ class TankWriteNodeHandler(object):
         # cache the type and settings on the root node so that 
         # they get serialized with the script:
         self.__update_knob_value(node, "tk_file_type", file_type)
+        self.__update_knob_value(node, "tk_file_extension", file_extension)
         self.__update_knob_value(node, "tk_file_type_settings", pickle.dumps(file_settings))
 
         # write the template name to the node so that we know it later
@@ -1629,7 +1631,7 @@ class TankWriteNodeHandler(object):
         
         :param node:         The current Shotgun Write node
         :param is_proxy:     If True then compute the proxy path, otherwise compute the standard render path
-        :returns:            Tuple containing (render template, width, height, output name)
+        :returns:            Tuple containing (render template, width, height, output name, extension)
         """
         render_template = self.__get_render_template(node, is_proxy)
         width = height = 0
@@ -1656,16 +1658,7 @@ class TankWriteNodeHandler(object):
             if "output" in render_template.keys or "channel" in render_template.keys:
                 output_name = node.knob(TankWriteNodeHandler.OUTPUT_KNOB_NAME).value()
 
-        # extension = node.knob('tk_file_type').value()
-
-        # decode extension from profile['file_extension']
-        # File open fires knob changed callbacks which call this even if path is cached.
-        # This is a problem if we are trying to restore settings
-        # of a node whose profile has been deleted.
-        # Setting extension to file_type in that case.
-        profile_name = node.knob('profile_name').value()
-        profile = self._profiles.get(profile_name, {})
-        extension = profile.get('file_extension') or node.knob('tk_file_type').value()
+        extension = node.knob('tk_file_extension').value()
 
         return (render_template, width, height, output_name, extension)
 
@@ -1694,6 +1687,7 @@ class TankWriteNodeHandler(object):
         :param width:              The width of the rendered images
         :param height:             The height of the rendered images
         :param output_name:        The toolkit output name specified by the user for this node
+        :param extension:          The image file extension that needs to be used
         :returns:                  The computed render path        
         """
 


### PR DESCRIPTION
Added a new key 'file_extension' to writenode settings. If this is present, it will be used. Otherwise, we default to using file_type as extension.